### PR TITLE
Fix the syntax highlight for case statement

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -264,7 +264,7 @@ syntax region  jsIfCondition matchgroup=jsIfParens start=+(+ end=+)+ contained c
 syntax keyword jsSwitch switch skipwhite skipempty nextgroup=jsSwitchCondition
 syntax region  jsSwitchBlock matchgroup=jsSwitchBraces start=+{+ end=+}+ contained contains=jsCaseStatement,@jsTop
 syntax region  jsSwitchCondition matchgroup=jsSwitchParens start=+(+ end=+)+ contained contains=@jsExpression,jsVariableType,jsComma skipwhite skipempty nextgroup=jsSwitchBlock
-syntax region  jsCaseStatement matchgroup=jsSwitchCase start=+\<\%(case\|default\)\>+ matchgroup=jsSwitchColon end=+:+ contained contains=@jsExpression keepend
+syntax region  jsCaseStatement matchgroup=jsSwitchCase start=+\<\%(case\|default\)\>+ matchgroup=jsSwitchColon end=+:+ contained contains=@jsExpression
 
 " Exceptions
 syntax keyword jsTry try skipwhite skipempty nextgroup=jsExceptionBlock

--- a/test/fixtures/test.flow.js
+++ b/test/fixtures/test.flow.js
@@ -1184,7 +1184,7 @@ switch (expression) {
   case "hello":
     console.log('hello');
     break;
-  case "world":
+  case "hello::world":
   case foo:
   case bar:
     break;

--- a/test/fixtures/test.js
+++ b/test/fixtures/test.js
@@ -480,7 +480,7 @@ switch (expression) {
   case "hello":
     console.log('hello');
     break;
-  case "world":
+  case "hello::world":
   case foo:
   case bar:
     break;


### PR DESCRIPTION
Not sure why I used `keepend` before, but remove it did fix #13 

![image](https://user-images.githubusercontent.com/3297602/97169673-65de5d80-17c5-11eb-8c38-45500d93b821.png)
