### PR TITLE
Allow jsTemplateString after comment for correct highlighting

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -62,7 +62,7 @@ syntax match   jsOptionalOperator +?\.+ contained skipwhite skipempty nextgroup=
 syntax match   jsOperator +??+ contained skipwhite skipwhite nextgroup=@jsExpression
 
 syntax cluster jsTopOperators contains=jsTopOperator,jsUnaryOperator
-syntax cluster jsOperators contains=jsRelationalOperator,jsTernary,jsOperator,jsTopOperator,jsBindOperator
+syntax cluster jsOperators contains=jsRelationalOperator,jsTernary,jsOperator,jsTopOperator,jsBindOperator,jsTemplateString
 
 " Modules
 " REFERENCE:


### PR DESCRIPTION
This will highlight JS code like the following correctly:

```js
const obj = {
  key: /* html */ `<some-html></some-html>`,
  other: "value"
};
```

Example screenshot comparison:
![image](https://github.com/user-attachments/assets/0e9e00d1-09a4-4e55-b00b-1b4aa692a2cc)

I'm not sure about any side-effects since I am not well versed in the arcane incarnations needed in `syntax` for vim 😄 

If this produces side-effects, just close this PR and ignore it.

Thanks!